### PR TITLE
fix: change to cli version in go.mod template

### DIFF
--- a/spellshape/services/plugin/template/go.mod.plush
+++ b/spellshape/services/plugin/template/go.mod.plush
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/hashicorp/go-plugin v1.4.4
-	github.com/spellshape/cli v0.25.3-0.20230104184106-15d7be221737
+	github.com/spellshape/cli nightly
 )
 
 replace (


### PR DESCRIPTION
fixes an issue for plugin scaffolding where the generated `go.mod` contained a no longer existing tag
Allows scaffolding tests to pass and will let plugin projects generated from the cli compile out of the box.